### PR TITLE
Update Torchx to work in an OpenShift Environment 

### DIFF
--- a/torchx/schedulers/ray/ray_driver.py
+++ b/torchx/schedulers/ray/ray_driver.py
@@ -45,7 +45,7 @@ except ModuleNotFoundError:
     from torchx.schedulers.ray.ray_common import RayActor, TORCHX_RANK0_HOST
 
 _logger: logging.Logger = logging.getLogger(__name__)
-_logger.setLevel(logging.getLevelName(os.environ.get("LOGLEVEL", "INFO")))
+_logger.setLevel(logging.getLevelName(os.environ.get("LOGLEVEL", "DEBUG")))
 logging.getLogger().addHandler(logging.StreamHandler(sys.stdout))
 
 
@@ -81,6 +81,9 @@ class CommandActor:  # pragma: no cover
         worker_evn.update(os.environ)
         worker_evn.update(self.env)
         worker_evn[TORCHX_RANK0_HOST] = master_addr
+        _logger.info(self.cmd)
+        _logger.info("worker env:", worker_evn)
+
         popen = subprocess.Popen(self.cmd, env=worker_evn)
 
         returncode = popen.wait()
@@ -96,12 +99,13 @@ class CommandActor:  # pragma: no cover
         return CommandActorScheduled(actor_id)
 
     def get_actor_address_and_port(self) -> Tuple[str, int]:
-        addr = ray.util.get_node_ip_address()
+        #addr = ray.util.get_node_ip_address()
+        addr = os.getenv("MY_POD_IP")
         with closing(socket.socket(socket.AF_INET, socket.SOCK_STREAM)) as s:
             s.bind(("", 0))
             s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             port = s.getsockname()[1]
-        return addr, port
+        return addr, 49782
 
 
 def load_actor_json(filename: str) -> List[RayActor]:
@@ -250,7 +254,7 @@ class RayDriver:
                         )
                         self.active_tasks.append(
                             actor.exec_module.remote(  # pyre-ignore
-                                "localhost", 0, result.id
+                                self.rank_0_address, self.rank_0_port, result.id
                             )
                         )
                     else:
@@ -293,6 +297,7 @@ class RayDriver:
 
 def main() -> None:  # pragma: no cover
     actors: List[RayActor] = load_actor_json("actors.json")
+    _logger.info(actors)
     driver = RayDriver(actors)
     ray.init(address="auto", namespace="torchx-ray")
     driver.init_placement_groups()

--- a/torchx/schedulers/ray_scheduler.py
+++ b/torchx/schedulers/ray_scheduler.py
@@ -330,7 +330,7 @@ if _has_ray:
 
         def _parse_app_id(self, app_id: str) -> Tuple[str, str]:
             # find index of '-' in the first :\d+-
-            m = re.search(r":\d+-", app_id)
+            m = re.search(r":\d+-|.com-", app_id)
             if m:
                 sep = m.span()[1]
                 addr = app_id[: sep - 1]


### PR DESCRIPTION
This PR includes 2 commits. 

The first is to the `ray_scheduler.py` that allows it to parse routes in addition to servce_name with port numbers. This is helpful when submitting jobs from a local environment into your cluster. 

The second commit adds some updates to `dist.py` and the `ray_driver.py` to ensure that the correct IP addresses get set in the ray workers to work properly in an OpenShift environment. 