### PR TITLE
Added volumes and Volume Mounts for ODH Config Map

### DIFF
--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -175,11 +175,13 @@ def role_to_pod(
     network: Optional[str],
 ) -> "V1Pod":
     from kubernetes.client.models import (  # noqa: F811 redefinition of unused
+        V1ConfigMapVolumeSource,
         V1Container,
         V1ContainerPort,
         V1EmptyDirVolumeSource,
         V1EnvVar,
         V1HostPathVolumeSource,
+        V1KeyToPath,
         V1LocalObjectReference,
         V1ObjectMeta,
         V1PersistentVolumeClaimVolumeSource,
@@ -233,9 +235,47 @@ def role_to_pod(
                 medium="Memory",
             ),
         ),
+        V1Volume(
+            name="odh-trusted-ca-cert",
+            config_map=V1ConfigMapVolumeSource(
+                name="odh-trusted-ca-bundle",
+                items=[
+                    V1KeyToPath(key="ca-bundle.crt", path="odh-custom-ca-bundle.crt")
+                ],
+                optional=True,
+            ),
+        ),
+        V1Volume(
+            name="odh-ca-cert",
+            config_map=V1ConfigMapVolumeSource(
+                name="odh-trusted-ca-bundle",
+                items=[V1KeyToPath(key="odh-ca-bundle.crt", path="odh-ca-bundle.crt")],
+                optional=True,
+            ),
+        ),
     ]
     volume_mounts = [
         V1VolumeMount(name=SHM_VOL, mount_path="/dev/shm"),
+        V1VolumeMount(
+            name="odh-trusted-ca-cert",
+            sub_path="odh-trusted-ca-bundle.crt",
+            mount_path="/etc/pki/tls/certs/odh-trusted-ca-bundle.crt",
+        ),
+        V1VolumeMount(
+            name="odh-trusted-ca-cert",
+            sub_path="odh-trusted-ca-bundle.crt",
+            mount_path="/etc/ssl/certs/odh-trusted-ca-bundle.crt",
+        ),
+        V1VolumeMount(
+            name="odh-ca-cert",
+            sub_path="odh-ca-bundle.crt",
+            mount_path="/etc/pki/tls/certs/odh-ca-bundle.crt",
+        ),
+        V1VolumeMount(
+            name="odh-ca-cert",
+            sub_path="odh-ca-bundle.crt",
+            mount_path="/etc/ssl/certs/odh-ca-bundle.crt",
+        ),
     ]
     security_context = V1SecurityContext()
 

--- a/torchx/schedulers/kubernetes_mcad_scheduler.py
+++ b/torchx/schedulers/kubernetes_mcad_scheduler.py
@@ -240,7 +240,7 @@ def role_to_pod(
             config_map=V1ConfigMapVolumeSource(
                 name="odh-trusted-ca-bundle",
                 items=[
-                    V1KeyToPath(key="ca-bundle.crt", path="odh-custom-ca-bundle.crt")
+                    V1KeyToPath(key="ca-bundle.crt", path="odh-trusted-ca-bundle.crt")
                 ],
                 optional=True,
             ),

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -365,7 +365,8 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                             name="odh-trusted-ca-bundle",
                             items=[
                                 V1KeyToPath(
-                                    key="ca-bundle.crt", path="odh-trusted-ca-bundle.crt"
+                                    key="ca-bundle.crt",
+                                    path="odh-trusted-ca-bundle.crt",
                                 )
                             ],
                             optional=True,

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -365,7 +365,7 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                             name="odh-trusted-ca-bundle",
                             items=[
                                 V1KeyToPath(
-                                    key="ca-bundle.crt", path="odh-custom-ca-bundle.crt"
+                                    key="ca-bundle.crt", path="odh-trusted-ca-bundle.crt"
                                 )
                             ],
                             optional=True,
@@ -702,7 +702,7 @@ spec:
           - configMap:
               items:
               - key: ca-bundle.crt
-                path: odh-custom-ca-bundle.crt
+                path: odh-trusted-ca-bundle.crt
               name: odh-trusted-ca-bundle
               optional: true
             name: odh-trusted-ca-cert
@@ -1371,7 +1371,7 @@ spec:
                         name="odh-trusted-ca-bundle",
                         items=[
                             V1KeyToPath(
-                                key="ca-bundle.crt", path="odh-custom-ca-bundle.crt"
+                                key="ca-bundle.crt", path="odh-trusted-ca-bundle.crt"
                             )
                         ],
                         optional=True,
@@ -1470,7 +1470,7 @@ spec:
                         name="odh-trusted-ca-bundle",
                         items=[
                             V1KeyToPath(
-                                key="ca-bundle.crt", path="odh-custom-ca-bundle.crt"
+                                key="ca-bundle.crt", path="odh-trusted-ca-bundle.crt"
                             )
                         ],
                         optional=True,

--- a/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
+++ b/torchx/schedulers/test/kubernetes_mcad_scheduler_test.py
@@ -239,11 +239,13 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
 
     def test_role_to_pod(self) -> None:
         from kubernetes.client.models import (
+            V1ConfigMapVolumeSource,
             V1Container,
             V1ContainerPort,
             V1EmptyDirVolumeSource,
             V1EnvVar,
             V1HostPathVolumeSource,
+            V1KeyToPath,
             V1LocalObjectReference,
             V1ObjectMeta,
             V1Pod,
@@ -314,6 +316,26 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                     mount_path="/dev/shm",
                 ),
                 V1VolumeMount(
+                    name="odh-trusted-ca-cert",
+                    sub_path="odh-trusted-ca-bundle.crt",
+                    mount_path="/etc/pki/tls/certs/odh-trusted-ca-bundle.crt",
+                ),
+                V1VolumeMount(
+                    name="odh-trusted-ca-cert",
+                    sub_path="odh-trusted-ca-bundle.crt",
+                    mount_path="/etc/ssl/certs/odh-trusted-ca-bundle.crt",
+                ),
+                V1VolumeMount(
+                    name="odh-ca-cert",
+                    sub_path="odh-ca-bundle.crt",
+                    mount_path="/etc/pki/tls/certs/odh-ca-bundle.crt",
+                ),
+                V1VolumeMount(
+                    name="odh-ca-cert",
+                    sub_path="odh-ca-bundle.crt",
+                    mount_path="/etc/ssl/certs/odh-ca-bundle.crt",
+                ),
+                V1VolumeMount(
                     name="mount-0",
                     mount_path="/dst",
                     read_only=True,
@@ -335,6 +357,30 @@ class KubernetesMCADSchedulerTest(unittest.TestCase):
                         name="dshm",
                         empty_dir=V1EmptyDirVolumeSource(
                             medium="Memory",
+                        ),
+                    ),
+                    V1Volume(
+                        name="odh-trusted-ca-cert",
+                        config_map=V1ConfigMapVolumeSource(
+                            name="odh-trusted-ca-bundle",
+                            items=[
+                                V1KeyToPath(
+                                    key="ca-bundle.crt", path="odh-custom-ca-bundle.crt"
+                                )
+                            ],
+                            optional=True,
+                        ),
+                    ),
+                    V1Volume(
+                        name="odh-ca-cert",
+                        config_map=V1ConfigMapVolumeSource(
+                            name="odh-trusted-ca-bundle",
+                            items=[
+                                V1KeyToPath(
+                                    key="odh-ca-bundle.crt", path="odh-ca-bundle.crt"
+                                )
+                            ],
+                            optional=True,
                         ),
                     ),
                     V1Volume(
@@ -627,6 +673,18 @@ spec:
             volumeMounts:
             - mountPath: /dev/shm
               name: dshm
+            - mountPath: /etc/pki/tls/certs/odh-trusted-ca-bundle.crt
+              name: odh-trusted-ca-cert
+              subPath: odh-trusted-ca-bundle.crt
+            - mountPath: /etc/ssl/certs/odh-trusted-ca-bundle.crt
+              name: odh-trusted-ca-cert
+              subPath: odh-trusted-ca-bundle.crt
+            - mountPath: /etc/pki/tls/certs/odh-ca-bundle.crt
+              name: odh-ca-cert
+              subPath: odh-ca-bundle.crt
+            - mountPath: /etc/ssl/certs/odh-ca-bundle.crt
+              name: odh-ca-cert
+              subPath: odh-ca-bundle.crt
             - mountPath: /dst
               name: mount-0
               readOnly: true
@@ -641,6 +699,20 @@ spec:
           - emptyDir:
               medium: Memory
             name: dshm
+          - configMap:
+              items:
+              - key: ca-bundle.crt
+                path: odh-custom-ca-bundle.crt
+              name: odh-trusted-ca-bundle
+              optional: true
+            name: odh-trusted-ca-cert
+          - configMap:
+              items:
+              - key: odh-ca-bundle.crt
+                path: odh-ca-bundle.crt
+              name: odh-trusted-ca-bundle
+              optional: true
+            name: odh-ca-cert
           - hostPath:
               path: /src
             name: mount-0
@@ -1258,7 +1330,9 @@ spec:
     def test_volume_mounts(self) -> None:
         scheduler = create_scheduler("test")
         from kubernetes.client.models import (
+            V1ConfigMapVolumeSource,
             V1EmptyDirVolumeSource,
+            V1KeyToPath,
             V1PersistentVolumeClaimVolumeSource,
             V1Volume,
             V1VolumeMount,
@@ -1292,6 +1366,30 @@ spec:
                     ),
                 ),
                 V1Volume(
+                    name="odh-trusted-ca-cert",
+                    config_map=V1ConfigMapVolumeSource(
+                        name="odh-trusted-ca-bundle",
+                        items=[
+                            V1KeyToPath(
+                                key="ca-bundle.crt", path="odh-custom-ca-bundle.crt"
+                            )
+                        ],
+                        optional=True,
+                    ),
+                ),
+                V1Volume(
+                    name="odh-ca-cert",
+                    config_map=V1ConfigMapVolumeSource(
+                        name="odh-trusted-ca-bundle",
+                        items=[
+                            V1KeyToPath(
+                                key="odh-ca-bundle.crt", path="odh-ca-bundle.crt"
+                            )
+                        ],
+                        optional=True,
+                    ),
+                ),
+                V1Volume(
                     name="mount-0",
                     persistent_volume_claim=V1PersistentVolumeClaimVolumeSource(
                         claim_name="name",
@@ -1307,6 +1405,26 @@ spec:
                     mount_path="/dev/shm",
                 ),
                 V1VolumeMount(
+                    name="odh-trusted-ca-cert",
+                    sub_path="odh-trusted-ca-bundle.crt",
+                    mount_path="/etc/pki/tls/certs/odh-trusted-ca-bundle.crt",
+                ),
+                V1VolumeMount(
+                    name="odh-trusted-ca-cert",
+                    sub_path="odh-trusted-ca-bundle.crt",
+                    mount_path="/etc/ssl/certs/odh-trusted-ca-bundle.crt",
+                ),
+                V1VolumeMount(
+                    name="odh-ca-cert",
+                    sub_path="odh-ca-bundle.crt",
+                    mount_path="/etc/pki/tls/certs/odh-ca-bundle.crt",
+                ),
+                V1VolumeMount(
+                    name="odh-ca-cert",
+                    sub_path="odh-ca-bundle.crt",
+                    mount_path="/etc/ssl/certs/odh-ca-bundle.crt",
+                ),
+                V1VolumeMount(
                     name="mount-0",
                     mount_path="/dst",
                     read_only=True,
@@ -1317,7 +1435,9 @@ spec:
     def test_device_mounts(self) -> None:
         scheduler = create_scheduler("test")
         from kubernetes.client.models import (
+            V1ConfigMapVolumeSource,
             V1HostPathVolumeSource,
+            V1KeyToPath,
             V1Volume,
             V1VolumeMount,
         )
@@ -1345,6 +1465,30 @@ spec:
             pod.spec.volumes[1:],
             [
                 V1Volume(
+                    name="odh-trusted-ca-cert",
+                    config_map=V1ConfigMapVolumeSource(
+                        name="odh-trusted-ca-bundle",
+                        items=[
+                            V1KeyToPath(
+                                key="ca-bundle.crt", path="odh-custom-ca-bundle.crt"
+                            )
+                        ],
+                        optional=True,
+                    ),
+                ),
+                V1Volume(
+                    name="odh-ca-cert",
+                    config_map=V1ConfigMapVolumeSource(
+                        name="odh-trusted-ca-bundle",
+                        items=[
+                            V1KeyToPath(
+                                key="odh-ca-bundle.crt", path="odh-ca-bundle.crt"
+                            )
+                        ],
+                        optional=True,
+                    ),
+                ),
+                V1Volume(
                     name="mount-0",
                     host_path=V1HostPathVolumeSource(
                         path="foo",
@@ -1361,6 +1505,26 @@ spec:
         self.assertEqual(
             pod.spec.containers[0].volume_mounts[1:],
             [
+                V1VolumeMount(
+                    name="odh-trusted-ca-cert",
+                    sub_path="odh-trusted-ca-bundle.crt",
+                    mount_path="/etc/pki/tls/certs/odh-trusted-ca-bundle.crt",
+                ),
+                V1VolumeMount(
+                    name="odh-trusted-ca-cert",
+                    sub_path="odh-trusted-ca-bundle.crt",
+                    mount_path="/etc/ssl/certs/odh-trusted-ca-bundle.crt",
+                ),
+                V1VolumeMount(
+                    name="odh-ca-cert",
+                    sub_path="odh-ca-bundle.crt",
+                    mount_path="/etc/pki/tls/certs/odh-ca-bundle.crt",
+                ),
+                V1VolumeMount(
+                    name="odh-ca-cert",
+                    sub_path="odh-ca-bundle.crt",
+                    mount_path="/etc/ssl/certs/odh-ca-bundle.crt",
+                ),
                 V1VolumeMount(
                     name="mount-0",
                     mount_path="bar",


### PR DESCRIPTION
Realtes to [RHOAIENG-3327](https://issues.redhat.com/browse/RHOAIENG-3327)
<!-- Change Summary -->
Added  volumes and Volume Mounts for ODH Config Map
## Test plan:
<!--  How you tested the change, ideally with a unit test :) -->
Unit tests are updated to match the changes.
## Test with SDK
* Clone this branch locally and create a torchx whl file with `python3 setup.py bdist_wheel`
* Install the whl file with `pip install dist/torchx-0.7.0.dev0-py3-none-any.whl`
* Make a change to the `pyproject.toml` file in the SDK
    * replace `codeflare-torchx = "0.6.0.dev1"` with `torchx = {path = "/path/to/your/torchx/dist/torchx-0.7.0.dev0-py3-none-any.whl"}`
* run `poetry build` and `pip install --force-reinstall /path/to/your/dist/codeflare_sdk-0.0.0.dev0-py3-none-any.whl`
* Run a Job through MCAD:
```
from codeflare_sdk.job.jobs import DDPJobDefinition
jobdef = DDPJobDefinition(
    name="mnistjob",
    script="mnist.py",
    # script="mnist_disconnected.py", # training script for disconnected environment
    scheduler_args={"namespace": "opendatahub"},
    j="1x1",
    gpu=0,
    cpu=1,
    memMB=8000,
    image="quay.io/project-codeflare/mnist-job-test:v0.0.1"
)
job = jobdef.submit()
```
* Verify the job has the correct Volumes/Volume mounts
